### PR TITLE
# 2022.10.07 [221006/CiscoStyleCli_v1.0.4.0] support variable arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,7 @@ test-tcmd2:
 test-tcmd3:
 	@echo " python3 tcmd3.py"
 	python3 tcmd3.py
+
+doc:
+	@echo "python3 help.py > CiscoStyleCli.help.txt"
+	python3 help.py > CiscoStyleCli.help.txt

--- a/help.py
+++ b/help.py
@@ -1,0 +1,3 @@
+import CiscoStyleCli
+csc = CiscoStyleCli.CiscoStyleCli()
+print(help(csc))

--- a/msg.md
+++ b/msg.md
@@ -125,3 +125,36 @@ pypi's id and passwd
 - bug fix -2
     - show the recommendation when i meet argument
 
+-----------------------
+# 2022.10.07 [221006/CiscoStyleCli_v1.0.4.0] support variable arguments
+
+- add new argument-type '...' : this is variable arguments.
+- ```
+            'endless' : {
+                '__attribute' : {
+                    'desc' : "multiple variant arguments",
+                    'type' : "argument",
+                    'argument-type': '...',
+                    'returnable' : "returnable",
+                },
+            },
+            ```
+
+- ```
+    $  python3 tcmd3.py list
+    argv: ['tcmd3.py', 'list']
+    functionname: _list
+     (commands) src (argument:['tiger_desktop_releaseL', 'bmw_icon_nad_releaseL', 'toyota_24dcm_releaseL', 'tiger_desktop_honda_releaseL', 'tiger_desktop_gen12_release']) project <CR> (argument:{'tiger_desktop_release': 'tiger release on x86', 'bmw_icon_nad_release': 'BMW iconnic sf24', 'toyota_24dcm_release': 'TOYOTA 24cy dcm', 'tiger_desktop_honda_release': 'HONDA 23MY', 'tiger_desktop_gen12_release': 'GM gen12'}) target <CR>
+     (commands) run (commands) desktop (commands) committest <CR> (argument:...) endless <CR>
+     (commands) quit <CR>
+     (commands) list <CR> (commands) detailed <CR>
+     (commands) list <CR> (commands) simple <CR>
+    
+    $  python3 tcmd3.py run desktop committest aa bb
+    argv: ['tcmd3.py', 'run', 'desktop', 'committest', 'aa', 'bb']
+    This is common type of prefunc and returnfunc function argument.
+    functionname: _common
+    function argument: v : {'__cmd__': ['run', 'desktop', 'committest'], 'endless': 'aa', '__return__': 'run desktop committest aa bb'}
+    Warning : set your returnfunc. this is templae function of prefunc and returnfunc argument.
+    ```
+

--- a/package/README.md
+++ b/package/README.md
@@ -47,11 +47,15 @@ CiscoStyleCli(rulePrintFile=None, infinite=False, prompt='FISH~~:', debug=False,
         - False if you want not to show message when self._common runs
 
 - Sample Codes
-    - [Basic Usage interactive test code](https://github.com/cheoljoo/fish/blob/main/package/test.py)
-    - [Basic Usage debug test code](https://github.com/cheoljoo/fish/blob/main/package/debug.py)
-    - [Basic Usage infinite loop interactive test code](https://github.com/cheoljoo/fish/blob/main/package/infinite.py)
-    - [Basic Usage test code with tiger tree syntax](https://github.com/cheoljoo/fish/blob/main/package/tcmd.py)
-    - [Basic Usage non-interactive (process command line with return) test code](https://github.com/cheoljoo/fish/blob/main/package/runCommand.py)
+    - [interactive normal mode](https://github.com/cheoljoo/fish/blob/main/package/test.py)
+    - [interactive debug mode](https://github.com/cheoljoo/fish/blob/main/package/debug.py)
+    - [interactive loop mode](https://github.com/cheoljoo/fish/blob/main/package/infinite.py)
+    - [non-interactive mode (run once with your input command with return key) test code](https://github.com/cheoljoo/fish/blob/main/package/runCommand.py)
+    - [interactive normal mode using tiger syntax tree](https://github.com/cheoljoo/fish/blob/main/package/tcmd.py)
+    - [interactive normal mode using tiger syntax tree : example 1](https://github.com/cheoljoo/fish/blob/main/package/tcmd1.py)
+    - [interactive normal mode using tiger syntax tree : example 2](https://github.com/cheoljoo/fish/blob/main/package/tcmd2.py)
+    - [interactive normal mode using tiger syntax tree : example 3 : variable arguments (argument-type is '...')](https://github.com/cheoljoo/fish/blob/main/package/tcmd3.py)
+
 
 ## interactive cisco command line interface
 ```python
@@ -97,221 +101,285 @@ csc.runCommand(cmd)
 
 # Methods
 ```
-addArgument(self, root, name, type, returnable, desc, prefunc=None, returnfunc=None, additionalDict=None, additionalList=None)
-    add node (argument type) in tree
-    argument type means variable type. it is not fixed string. user should put the variant value.
-        - argument type : int
-        - argument type : str
-        - argument type : float
-        - argument type : [strA,strB,strC,...]  - list type : user can use one string in this list  (all are string)
-        - argument type : { key1:value1 , key2:value2 , ...} - dictionary type : user can use one key in this dictionary (all key and value are string)
-    
-    :command tree example:
-        gethost choose1 choose <CR>
-        gethost choose2 target <CR>
-        gethost choose3 shoot <CR>
-        quit <CR>
-        list <CR> detailed <CR>
-        list <CR> simple <CR>
-    
-    :code example:
-        csc = CiscoStyleCli.CiscoStyleCli()
-        cmdTop = {}
-        gethostCmd = csc.addCmd(cmdTop,'gethost','command',"", "gethosthelp")                                                            # level 1
-        tmp = csc.addCmd(gethostCmd,'choose1','command',"", "choose type1",prefunc=rc.showHost,additionalDict={'0':'tiger','1':'animal'})        # level 2
-        tmp = csc.addArgument(tmp,'choose','int',"returnable", "type integer",prefunc=rc.showHost,additionalDict={'0':'tiger','1':'animal'})     # level 3
-        quitCmd = self.addCmd(cmdTop ,'quit','command',"returnable", "exit",returnfunc=self._quit)                                       # level 1
-        listCmd = self.addCmd(cmdTop ,'list','command',"returnable", "show command line interface list",returnfunc=self._list)           # level 1
-        tmp = self.addCmd(listCmd ,'detailed','command',"returnable", "show detailed command line interface list",returnfunc=self._listDetailed) # level 2
-        tmp = self.addCmd(listCmd ,'simple','command',"returnable", "show simple command line interface list",returnfunc=self._listSimple)       # level 2
-        csc.setCliRule(cmdTop)
-    
-    :param root: parent node
-    :param name: argument name - retValue will have dictionary {name:value}
-    :param type: argument type - int , float , str , list , dict
-            when you use list and dict , it will give the recommendation with these list and dictionary contents (keys).
-    :param returnable: 'returnable' when we run something after strike 'return' key.  
-    :param desc: description
-    :param prefunc: function pointer - it will be run if your command meets this function.  show the example to understand easily
-    :param returnfunc: function pointer - it will be run when returnable == 'returnable' and you strike 'return' key.  default returnfunc=self._common
-            v : {'__cmd__': ['gethost', 'choose3'], 'shoot': {'choice': '2', 'data': {'0': 'car', '1': 'tiger', '2': 'telematics'}}, '__return__': 'gethost choose3 2'}
-            v : {'__cmd__': ['gethost', 'choose2'], 'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}, '__return__': 'gethost choose2 tiger'}
-    :param additionalDict: give this information to argument of prefunc and returnfunc. 
-            'shoot': {'choice': '2', 'data': {'0': 'car', '1': 'tiger', '2': 'telematics'}}
-    :param additionalList: give this information to argument of prefunc and returnfunc. 
-            'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}
-    :return: current node of tree
+Help on CiscoStyleCli in module CiscoStyleCli object:
 
-addCmd(self, root, command, type, returnable, desc, prefunc=None, returnfunc=None, additionalDict=None, additionalList=None)
-    add node (command type) in tree
-    it is fixed string.
-    
-    :command tree example:
-        gethost choose1 choose <CR>
-        gethost choose2 target <CR>
-        gethost choose3 shoot <CR>
-        quit <CR>
-        list <CR> detailed <CR>
-        list <CR> simple <CR>
-    
-    :code example:
-        csc = CiscoStyleCli.CiscoStyleCli()
-        cmdTop = {}
-        gethostCmd = csc.addCmd(cmdTop,'gethost','command',"", "gethosthelp")                                                            # level 1
-        tmp = csc.addCmd(gethostCmd,'choose1','command',"", "choose type1",prefunc=rc.showHost,additionalDict={'0':'tiger','1':'animal'})        # level 2
-        tmp = csc.addArgument(tmp,'choose','int',"returnable", "type integer",prefunc=rc.showHost,additionalDict={'0':'tiger','1':'animal'})     # level 3
-        quitCmd = self.addCmd(cmdTop ,'quit','command',"returnable", "exit",returnfunc=self._quit)                                       # level 1
-        listCmd = self.addCmd(cmdTop ,'list','command',"returnable", "show command line interface list",returnfunc=self._list)           # level 1
-        tmp = self.addCmd(listCmd ,'detailed','command',"returnable", "show detailed command line interface list",returnfunc=self._listDetailed) # level 2
-        tmp = self.addCmd(listCmd ,'simple','command',"returnable", "show simple command line interface list",returnfunc=self._listSimple)       # level 2
-        csc.setCliRule(cmdTop)
-    
-    :param root: parent node
-    :param command: command name - retValue will have dictionary {name:value}
-    :param type: command
-    :param returnable: 'returnable' when we run something after strike 'return' key.  
-    :param desc: description
-    :param prefunc: function pointer - it will be run if your command meets this function.  show the example to understand easily
-    :param returnfunc: function pointer - it will be run when returnable == 'returnable' and you strike 'return' key.  default returnfunc=self._common
-            v : {'__cmd__': ['gethost', 'choose3'], 'shoot': {'choice': '2', 'data': {'0': 'car', '1': 'tiger', '2': 'telematics'}}, '__return__': 'gethost choose3 2'}
-            v : {'__cmd__': ['gethost', 'choose2'], 'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}, '__return__': 'gethost choose2 tiger'}
-    :param additionalDict: give this information to argument of prefunc and returnfunc. 
-            'shoot': {'choice': '2', 'data': {'0': 'car', '1': 'tiger', '2': 'telematics'}}
-    :param additionalList: give this information to argument of prefunc and returnfunc. 
-            'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}
-    :return: current node of tree
-
-checkCmd(self, cmd)
-    check whether this cmd is right and run registered function in prefunc and returnfunc arguments of addArgument() or addCmd()
-    return the location from rootCmd following cmd  for guiding current and next arguments
-    self.c : current input character
-    
-    flows
-        - while process each token (word) before last token (word)
-            move the next tree node each token
-            return current node if token has wrong input against tree
-        - process last token (word)
-            if input is return character,
-                if returnable , run returnfunc
-            if input is space or tab character,
-                find longestmatch
-        - return retValue
-    call function of prefunc and returnfunc
-        - prefunc and returnfunc has only one dictionary argument including all information
-    
-    :param cmd: input command line
-    :return root: node of tree for next argument.
-    :return lastWord: last stroke word
-    :return retValue: all your input information
-            example) {'__cmd__': ['gethost', 'choose2'], 'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}, '__return__': 'gethost choose2 tiger'}
-    :return quoteflag: False or True according to the quotation counts
-    :return isFinishedFromReturn: False or True.   if it returns from input "return" , it is True.
-
-run(self)
-    main part of cisco command line interface
-    meet the prompt for your input
-    get string from your input
-    run() will have infinite loop before meeting quit() if you set infinite argument in __init__() as True.
-    :return: retValue with all your input information
-            example) {'__cmd__': ['gethost', 'choose2'], 'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}, '__return__': 'gethost choose2 tiger'}
-
-runCommand(self, cmd)
-    non-interactive run command
-    
-    :param cmd: retValue with all your input information
-            example) {'__cmd__': ['gethost', 'choose2'], 'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}, '__return__': 'gethost choose2 tiger'}
-
-setCliRule(self, rule)
-    set rule 
-    rule is generated from addCmd() and addArgument() functions.
-    finally it set the self._comon(v) when returnable is on or this is last token (word).
-      and it will add 'list' and 'quit' command automatically if you do not set it.
-    
-    :code example:
-        csc = CiscoStyleCli.CiscoStyleCli()
-        remoteCmd = {}
-        gethostCmd = csc.addCmd(remoteCmd,'gethost','command',"", "gethosthelp")
-        tmp = csc.addCmd(gethostCmd,'choose1','command',"", "choose type1",prefunc=rc.showHost,additionalDict={'0':'tiger','1':'animal'})
-        tmp = csc.addArgument(tmp,'choose','int',"returnable", "type integer",prefunc=rc.showHost,additionalDict={'0':'tiger','1':'animal'})
-        tmp = csc.addCmd(gethostCmd,'choose2','command',"", "choose type2",additionalDict={'0':'tiger','1':'animal'})
-        tmp = csc.addArgument(tmp,'target',['cheetah','tiger','fish','turtle','tigiris'],"returnable", "type from the list")
-        tmp = csc.addCmd(gethostCmd,'choose3','command',"", "choose type3",additionalDict={'0':'tiger','1':'animal'})
-        tmp = csc.addArgument(tmp,'shoot',{'0':'car','1':'tiger','2':'telematics'},"returnable", "type key from the dictionary")
-        csc.setCliRule(remoteCmd)
-    
-    verification method: you can show the tree with the following command
-        list<CR>
-        list simple<CR>
-        list detailed<CR>
-        
-    Args:
-        rule (dict): rule dictionary tree made by addCmd() and addArgument()
-
-setCliRuleTcmd(self, top)
-    set rule for our tiger project (Tcmd : Tiger Command)
-    it has different sequence of dictionary tree.
-    finally it set the self._comon(v) when returnable is on or this is last token (word).
-      and it will add 'list' and 'quit' command automatically if you do not set it.
-    
-    :code example:
-        TOP = {}
-        projectList = ['tiger','cheetah','fish']
-        TOP ['register'] = {
-            '__attribute' : {
-                'type' : "command",
-                'desc' : "registration~~",
-                'returnable' : "returnable"
-                },
-            'name' : {
-                '__attribute' : {
-                    'type' : "command",
-                    'desc' : "name~~",
-                    'returnable' : "",
-                }
-            },
-            'target' : {
-                'next-target' : {}
-            },
-            'target2' : {
-                'next2-target' : {
-                    '__attribute' : {
-                        'desc' : "next target",
-                        'returnable' : "",
-                    }
-                }
-            },
-            'vbee' : {
-                'project' : {
-                    '__attribute' : {
-                        'desc' : "choose from list",
-                        'type' : 'argument',
-                        'argument-type' : projectList
-                    }
-                }
-            }
-        }
-        csc.setCliRuleTcmd(TOP)
-    
-    if you do not '__attribute' , we will set as default
-        ['__attribute']['returnable'] = ""
-        ['__attribute']['type'] = 'command'
-        ['__attribute']['returnable'] = ""
-        ['__attribute']['desc'] = ""
-        ['__attribute']['argument-type'] = None
-        if you want to use dictionary or list , 
-            ['__attribute']['type'] = 'argument'
-            ['__attribute']['argument-type'] = one dimentional dictionary or list
-    
-    verification method: you can show the tree with the following command
-        list<CR>
-        list simple<CR>
-        list detailed<CR>
-    
-    :param top: rule dictionary tree with different type
+class CiscoStyleCli(builtins.object)
+ |  CiscoStyleCli(rulePrintFile=None, infinite=False, prompt='FISH~~:', debug=False, isUseDefaultCommon=True)
+ |  
+ |  This Class runs function from command string
+ |  Cisco Style give the recommandation when you can use easily.
+ |  if you do not know what you do , press space or tab.
+ |  then CiscoStyleCli shows the recommendation with help description.
+ |  
+ |  1. interactive cisco command line interface
+ |  from CiscoStyleCli import CiscoStyleCli
+ |  csc = CiscoStyleCli.CiscoStyleCli()
+ |  csc.run()
+ |      - show the prompt to get your command (interactive mode)
+ |      - press enter key , this function will return
+ |  
+ |  2. endless interactive cisco command line interface
+ |  from CiscoStyleCli import CiscoStyleCli
+ |  csc = CiscoStyleCli.CiscoStyleCli(infinite=True)
+ |  csc.run() 
+ |      - it has infinite loop
+ |      - show the prompt to get your command (interactive mode)
+ |      - you can quit when you meet quit command or quit()
+ |  
+ |  3. non-interactive run command
+ |  from CiscoStyleCli import CiscoStyleCli
+ |  csc = CiscoStyleCli.CiscoStyleCli()
+ |  csc.runCommand(cmd)
+ |      - run your command (non-interactive mode)
+ |  
+ |  :param rulePrintFile: file name to print the tree
+ |  :param infinite: False (default) or True 
+ |          True if you want infinite loop. 
+ |          False if want to finish when you stroke 'return' key.
+ |  :param prompt: your prompt
+ |  :param debug: False (default) or True
+ |          True if you want to print more information
+ |  :param isUseDefaultCommon: True (default) or False
+ |          False if you want not to show message when self._common runs
+ |  
+ |  Methods defined here:
+ |  
+ |  __init__(self, rulePrintFile=None, infinite=False, prompt='FISH~~:', debug=False, isUseDefaultCommon=True)
+ |      initalize
+ |      it has only 2 commands : quit , list
+ |      
+ |      :param rulePrintFile: file name to print the tree
+ |      :param infinite: False (default) or True 
+ |              True if you want infinite loop. 
+ |              False if want to finish when you stroke 'return' key.
+ |      :param prompt: your prompt
+ |      :param debug: False (default) or True
+ |              True if you want to print more information
+ |      :param isUseDefaultCommon: True (default) or False
+ |              False if you want not to show message when self._common runs
+ |  
+ |  addArgument(self, root, name, type, returnable, desc, prefunc=None, returnfunc=None, additionalDict=None, additionalList=None)
+ |      add node (argument type) in tree
+ |      argument type means variable type. it is not fixed string. user should put the variant value.
+ |          - argument type : int
+ |          - argument type : str
+ |          - argument type : float
+ |          - argument type : [strA,strB,strC,...]  - list type : user can use one string in this list  (all are string)
+ |          - argument type : { key1:value1 , key2:value2 , ...} - dictionary type : user can use one key in this dictionary (all key and value are string)
+ |      
+ |      :command tree example:
+ |          gethost choose1 choose <CR>
+ |          gethost choose2 target <CR>
+ |          gethost choose3 shoot <CR>
+ |          quit <CR>
+ |          list <CR> detailed <CR>
+ |          list <CR> simple <CR>
+ |      
+ |      :code example:
+ |          from CiscoStyleCli import CiscoStyleCli
+ |          csc = CiscoStyleCli.CiscoStyleCli()
+ |          cmdTop = {}
+ |          gethostCmd = csc.addCmd(cmdTop,'gethost','command',"", "gethosthelp")                                                            # level 1
+ |          tmp = csc.addCmd(gethostCmd,'choose1','command',"", "choose type1",prefunc=rc.showHost,additionalDict={'0':'tiger','1':'animal'})        # level 2
+ |          tmp = csc.addArgument(tmp,'choose','int',"returnable", "type integer",prefunc=rc.showHost,additionalDict={'0':'tiger','1':'animal'})     # level 3
+ |          quitCmd = self.addCmd(cmdTop ,'quit','command',"returnable", "exit",returnfunc=self._quit)                                       # level 1
+ |          listCmd = self.addCmd(cmdTop ,'list','command',"returnable", "show command line interface list",returnfunc=self._list)           # level 1
+ |          tmp = self.addCmd(listCmd ,'detailed','command',"returnable", "show detailed command line interface list",returnfunc=self._listDetailed) # level 2
+ |          tmp = self.addCmd(listCmd ,'simple','command',"returnable", "show simple command line interface list",returnfunc=self._listSimple)       # level 2
+ |          csc.setCliRule(cmdTop)
+ |      
+ |      :param root: parent node
+ |      :param name: argument name - retValue will have dictionary {name:value}
+ |      :param type: argument type - int , float , str , list , dict
+ |              when you use list and dict , it will give the recommendation with these list and dictionary contents (keys).
+ |      :param returnable: 'returnable' when we run something after strike 'return' key.  
+ |      :param desc: description
+ |      :param prefunc: function pointer - it will be run if your command meets this function.  show the example to understand easily
+ |      :param returnfunc: function pointer - it will be run when returnable == 'returnable' and you strike 'return' key.  default returnfunc=self._common
+ |              v : {'__cmd__': ['gethost', 'choose3'], 'shoot': {'choice': '2', 'data': {'0': 'car', '1': 'tiger', '2': 'telematics'}}, '__return__': 'gethost choose3 2'}
+ |              v : {'__cmd__': ['gethost', 'choose2'], 'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}, '__return__': 'gethost choose2 tiger'}
+ |      :param additionalDict: give this information to argument of prefunc and returnfunc. 
+ |              'shoot': {'choice': '2', 'data': {'0': 'car', '1': 'tiger', '2': 'telematics'}}
+ |      :param additionalList: give this information to argument of prefunc and returnfunc. 
+ |              'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}
+ |      :return: current node of tree
+ |  
+ |  addCmd(self, root, command, type, returnable, desc, prefunc=None, returnfunc=None, additionalDict=None, additionalList=None)
+ |      add node (command type) in tree
+ |      it is fixed string.
+ |      
+ |      :command tree example:
+ |          gethost choose1 choose <CR>
+ |          gethost choose2 target <CR>
+ |          gethost choose3 shoot <CR>
+ |          quit <CR>
+ |          list <CR> detailed <CR>
+ |          list <CR> simple <CR>
+ |      
+ |      :code example:
+ |          from CiscoStyleCli import CiscoStyleCli
+ |          csc = CiscoStyleCli.CiscoStyleCli()
+ |          cmdTop = {}
+ |          gethostCmd = csc.addCmd(cmdTop,'gethost','command',"", "gethosthelp")                                                            # level 1
+ |          tmp = csc.addCmd(gethostCmd,'choose1','command',"", "choose type1",prefunc=rc.showHost,additionalDict={'0':'tiger','1':'animal'})        # level 2
+ |          tmp = csc.addArgument(tmp,'choose','int',"returnable", "type integer",prefunc=rc.showHost,additionalDict={'0':'tiger','1':'animal'})     # level 3
+ |          quitCmd = self.addCmd(cmdTop ,'quit','command',"returnable", "exit",returnfunc=self._quit)                                       # level 1
+ |          listCmd = self.addCmd(cmdTop ,'list','command',"returnable", "show command line interface list",returnfunc=self._list)           # level 1
+ |          tmp = self.addCmd(listCmd ,'detailed','command',"returnable", "show detailed command line interface list",returnfunc=self._listDetailed) # level 2
+ |          tmp = self.addCmd(listCmd ,'simple','command',"returnable", "show simple command line interface list",returnfunc=self._listSimple)       # level 2
+ |          csc.setCliRule(cmdTop)
+ |      
+ |      :param root: parent node
+ |      :param command: command name - retValue will have dictionary {name:value}
+ |      :param type: command
+ |      :param returnable: 'returnable' when we run something after strike 'return' key.  
+ |      :param desc: description
+ |      :param prefunc: function pointer - it will be run if your command meets this function.  show the example to understand easily
+ |      :param returnfunc: function pointer - it will be run when returnable == 'returnable' and you strike 'return' key.  default returnfunc=self._common
+ |              v : {'__cmd__': ['gethost', 'choose3'], 'shoot': {'choice': '2', 'data': {'0': 'car', '1': 'tiger', '2': 'telematics'}}, '__return__': 'gethost choose3 2'}
+ |              v : {'__cmd__': ['gethost', 'choose2'], 'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}, '__return__': 'gethost choose2 tiger'}
+ |      :param additionalDict: give this information to argument of prefunc and returnfunc. 
+ |              'shoot': {'choice': '2', 'data': {'0': 'car', '1': 'tiger', '2': 'telematics'}}
+ |      :param additionalList: give this information to argument of prefunc and returnfunc. 
+ |              'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}
+ |      :return: current node of tree
+ |  
+ |  checkCmd(self, cmd)
+ |      check whether this cmd is right and run registered function in prefunc and returnfunc arguments of addArgument() or addCmd()
+ |      return the location from rootCmd following cmd  for guiding current and next arguments
+ |      self.c : current input character
+ |      
+ |      flows
+ |          - while process each token (word) before last token (word)
+ |              move the next tree node each token
+ |              return current node if token has wrong input against tree
+ |          - process last token (word)
+ |              if input is return character,
+ |                  if returnable , run returnfunc
+ |              if input is space or tab character,
+ |                  find longestmatch
+ |          - return retValue
+ |      call function of prefunc and returnfunc
+ |          - prefunc and returnfunc has only one dictionary argument including all information
+ |      
+ |      :param cmd: input command line
+ |      :return root: node of tree for next argument.
+ |      :return lastWord: last stroke word
+ |      :return retValue: all your input information
+ |              example) {'__cmd__': ['gethost', 'choose2'], 'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}, '__return__': 'gethost choose2 tiger'}
+ |      :return quoteflag: False or True according to the quotation counts
+ |      :return isFinishedFromReturn: False or True.   if it returns from input "return" , it is True.
+ |  
+ |  run(self)
+ |      main part of cisco command line interface
+ |      meet the prompt for your input
+ |      get string from your input
+ |      run() will have infinite loop before meeting quit() if you set infinite argument in __init__() as True.
+ |      :return: retValue with all your input information
+ |              example) {'__cmd__': ['gethost', 'choose2'], 'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}, '__return__': 'gethost choose2 tiger'}
+ |  
+ |  runCommand(self, cmd)
+ |      non-interactive run command
+ |      
+ |      :param cmd: retValue with all your input information
+ |              example) {'__cmd__': ['gethost', 'choose2'], 'target': {'choice': 'tiger', 'data': ['cheetah', 'tiger', 'fish', 'turtle', 'tigiris']}, '__return__': 'gethost choose2 tiger'}
+ |  
+ |  setCliRule(self, rule)
+ |      set rule 
+ |      rule is generated from addCmd() and addArgument() functions.
+ |      finally it set the self._comon(v) when returnable is on or this is last token (word).
+ |        and it will add 'list' and 'quit' command automatically if you do not set it.
+ |      
+ |      :code example:
+ |          from CiscoStyleCli import CiscoStyleCli
+ |          csc = CiscoStyleCli.CiscoStyleCli()
+ |          remoteCmd = {}
+ |          gethostCmd = csc.addCmd(remoteCmd,'gethost','command',"", "gethosthelp")
+ |          tmp = csc.addCmd(gethostCmd,'choose1','command',"", "choose type1",prefunc=rc.showHost,additionalDict={'0':'tiger','1':'animal'})
+ |          tmp = csc.addArgument(tmp,'choose','int',"returnable", "type integer",prefunc=rc.showHost,additionalDict={'0':'tiger','1':'animal'})
+ |          tmp = csc.addCmd(gethostCmd,'choose2','command',"", "choose type2",additionalDict={'0':'tiger','1':'animal'})
+ |          tmp = csc.addArgument(tmp,'target',['cheetah','tiger','fish','turtle','tigiris'],"returnable", "type from the list")
+ |          tmp = csc.addCmd(gethostCmd,'choose3','command',"", "choose type3",additionalDict={'0':'tiger','1':'animal'})
+ |          tmp = csc.addArgument(tmp,'shoot',{'0':'car','1':'tiger','2':'telematics'},"returnable", "type key from the dictionary")
+ |          csc.setCliRule(remoteCmd)
+ |      
+ |      verification method: you can show the tree with the following command
+ |          list<CR>
+ |          list simple<CR>
+ |          list detailed<CR>
+ |          
+ |      Args:
+ |          rule (dict): rule dictionary tree made by addCmd() and addArgument()
+ |  
+ |  setCliRuleTcmd(self, top)
+ |      set rule for our tiger project (Tcmd : Tiger Command)
+ |      it has different sequence of dictionary tree.
+ |      finally it set the self._comon(v) when returnable is on or this is last token (word).
+ |        and it will add 'list' and 'quit' command automatically if you do not set it.
+ |      
+ |      :code example:
+ |          TOP = {}
+ |          projectList = ['tiger','cheetah','fish']
+ |          TOP ['register'] = {
+ |              '__attribute' : {
+ |                  'type' : "command",
+ |                  'desc' : "registration~~",
+ |                  'returnable' : "returnable"
+ |                  },
+ |              'name' : {
+ |                  '__attribute' : {
+ |                      'type' : "command",
+ |                      'desc' : "name~~",
+ |                      'returnable' : "",
+ |                  }
+ |              },
+ |              'target' : {
+ |                  'next-target' : {}
+ |              },
+ |              'target2' : {
+ |                  'next2-target' : {
+ |                      '__attribute' : {
+ |                          'desc' : "next target",
+ |                          'returnable' : "",
+ |                      }
+ |                  }
+ |              },
+ |              'vbee' : {
+ |                  'project' : {
+ |                      '__attribute' : {
+ |                          'desc' : "choose from list",
+ |                          'type' : 'argument',
+ |                          'argument-type' : projectList
+ |                      }
+ |                  }
+ |              }
+ |          }
+ |          csc.setCliRuleTcmd(TOP)
+ |      
+ |      if you do not '__attribute' , we will set as default
+ |          ['__attribute']['returnable'] = ""
+ |          ['__attribute']['type'] = 'command'
+ |          ['__attribute']['returnable'] = ""
+ |          ['__attribute']['desc'] = ""
+ |          ['__attribute']['argument-type'] = None
+ |          if you want to use dictionary or list , 
+ |              ['__attribute']['type'] = 'argument'
+ |              ['__attribute']['argument-type'] = one dimentional dictionary or list
+ |      
+ |      verification method: you can show the tree with the following command
+ |          list<CR>
+ |          list simple<CR>
+ |          list detailed<CR>
+ |      
+ |      Args:
+ |          top(dict) : rule dictionary tree with different type
+ |  
+ |  ----------------------------------------------------------------------
 ```
 
 # pypi
 - Use pypi : https://pypi.org/project/ciscostylecli/
 
+# work history
 - [work record - lang:korean](https://github.com/cheoljoo/fish/blob/main/msg.md)
 

--- a/package/package.md
+++ b/package/package.md
@@ -1,0 +1,21 @@
+### 2.3.2. make package
+- ```
+    cd package
+    python3 -m pip install --upgrade setuptools wheel
+    python3 setup.py sdist bdist_wheel
+    ```
+- verify the result
+    - ```txt
+        package/dist  $  ls -l
+        total 40
+        -rw-rw-r-- 1 cheoljoo.lee cheoljoo.lee 15326 Sep 30 23:04 ciscostylecli-1.0.0.0-py3-none-any.whl
+        -rw-rw-r-- 1 cheoljoo.lee cheoljoo.lee 15483 Sep 30 23:04 ciscostylecli-1.0.0.0.tar.gz
+        ```
+### 2.3.3. upload package (distribution)
+- ```
+    cd package
+    python3 -m pip install --upgrade twine
+    python3 -m twine upload --skip-existing dist/*
+    pypi's id and passwd
+    ```
+

--- a/package/setup.py
+++ b/package/setup.py
@@ -26,7 +26,7 @@ HERE = pathlib.Path(__file__).parent
 README = (HERE / 'README.md').read_text()
 
 setup(name='ciscostylecli',
-      version='1.0.3.0',
+      version='1.0.4.0',
       description='A Python package for command line interface like cisco',
       long_description = README,
       long_description_content_type = "text/markdown",

--- a/package/tcmd.py
+++ b/package/tcmd.py
@@ -1,4 +1,5 @@
 from CiscoStyleCli import CiscoStyleCli
+import sys
 
 #print(help(CiscoStyleCli))
 
@@ -6,42 +7,82 @@ csc = CiscoStyleCli.CiscoStyleCli(prompt="TCMD>")
 #print(csc.__doc__)
 
 TOP = {}
-projectList = ['tiger','cheetah','fish']
-TOP ['register'] = {
+projectList = ['tiger_desktop_release' , 'bmw_icon_nad_release' , 'toyota_24dcm_release' , 'tiger_desktop_honda_release' , 'tiger_desktop_gen12_release']
+TOP ['src'] = {
     '__attribute' : {
-        'type' : "command",
-        'desc' : "registration~~",
-        'returnable' : "returnable"
+        'desc' : "get source code",
     },
-    'name' : {
+    'project' : {
         '__attribute' : {
-            'type' : "command",
-            'desc' : "name~~",
-            'returnable' : "",
-        }
-    },
-    'target' : {
-        'next-target' : {}
-    },
-    'target2' : {
-        'next2-target' : {
+            'type' : "argument",
+            'desc' : "project name",
+            'argument-type': projectList,
+            'returnable' : "returnable",
+        },
+        'target' : {
             '__attribute' : {
-                'desc' : "next target",
-                'returnable' : "",
+                'type' : "argument",
+                'desc' : "target",
+                'argument-type': 'str',
+                'returnable' : "returnable",
+            },
+        },
+    },
+}
+TOP ['run'] = {
+    '__attribute' : {
+        'desc' : "run",
+    },
+    'desktop' : {
+        '__attribute' : {
+            'desc' : "desktop",
+        },
+        'committest' : {
+            '__attribute' : {
+                'desc' : "committest",
+                'type' : 'command',
+                'returnable' : "returnable",
             }
         }
     },
-    'vbee' : {
+}
+TOP ['test'] = {
+    '__attribute' : {
+        'desc' : "build & test",
+    },
+    'daily' : {
+        '__attribute' : {
+            'desc' : "daily",
+        },
         'project' : {
             '__attribute' : {
-                'desc' : "choose from list",
+                'desc' : "project name",
                 'type' : 'argument',
-                'argument-type' : projectList
+                'argument-type': projectList,
+                'returnable' : "returnable",
+            }
+        }
+    },
+    'vt' : {
+        '__attribute' : {
+            'desc' : "vbee test",
+        },
+        'project' : {
+            '__attribute' : {
+                'desc' : "project name",
+                'type' : 'argument',
+                'argument-type': projectList,
+                'returnable' : "returnable",
             }
         }
     }
 }
 csc.setCliRuleTcmd(TOP)
 
-csc.run()
+if len(sys.argv) > 1:
+    print("argv:",sys.argv)
+    x = ' '.join(sys.argv[1:])
+    csc.runCommand(x)
+else :
+    csc.run()
 

--- a/package/tcmd1.py
+++ b/package/tcmd1.py
@@ -1,0 +1,50 @@
+from CiscoStyleCli import CiscoStyleCli
+import sys
+
+#print(help(CiscoStyleCli))
+
+csc = CiscoStyleCli.CiscoStyleCli(prompt="TCMD>")
+#print(csc.__doc__)
+
+TOP = {
+    'src': {
+        '__attribute' : {
+           'desc' : "get project source code"
+        },
+    },
+    'build': {
+            'apps': {
+                '__attribute' : {
+                   'desc' : "build  tiger-desktop ipk image file"
+                },
+            },
+            'target': {
+                'apps': None,
+            },
+            'vbee': {
+                '__attribute' : {
+                   'desc' : "build  & get ipk image with using VBEE server"
+                },
+            },
+    },
+    'run': {
+        '__attribute' : {
+           'desc' : "run tiger-desktop or TRDK(target-device)"
+        },
+    },
+    'test': {
+        '__attribute' : {
+           'desc' : "test tiger-desktop or TRDK(target-device). All TestCase of modules (auto_test_*.csv) will be executed"
+        },
+    },
+}
+projectList = ['tiger_desktop_release' , 'bmw_icon_nad_release' , 'toyota_24dcm_release' , 'tiger_desktop_honda_release' , 'tiger_desktop_gen12_release']
+csc.setCliRuleTcmd(TOP)
+
+if len(sys.argv) > 1:
+    print("argv:",sys.argv)
+    x = ' '.join(sys.argv[1:])
+    csc.runCommand(x)
+else :
+    csc.run()
+

--- a/package/tcmd2.py
+++ b/package/tcmd2.py
@@ -3,11 +3,13 @@ import sys
 
 def runReturnFunc(v):
     functionNameAsString = sys._getframe().f_code.co_name
+    print("----")
     print("This is common type of prefunc and returnfunc function argument.")
     print("functionname:",functionNameAsString)
     if v:
         print("function argument: v :",v)
     print('run your code with arbument v')
+    print("----")
 
 #print(help(CiscoStyleCli))
 
@@ -15,7 +17,7 @@ csc = CiscoStyleCli.CiscoStyleCli(prompt="TCMD:>")
 #print(csc.__doc__)
 
 TOP = {}
-projectList = ['tiger_desktop_release' , 'bmw_icon_nad_release' , 'toyota_24dcm_release' , 'tiger_desktop_honda_release' , 'tiger_desktop_gen12_release']
+projectList = ['tiger_desktop_releaseL' , 'bmw_icon_nad_releaseL' , 'toyota_24dcm_releaseL' , 'tiger_desktop_honda_releaseL' , 'tiger_desktop_gen12_release']
 projectDict = {
     'tiger_desktop_release' : 'tiger release on x86',
     'bmw_icon_nad_release' : 'BMW iconnic sf24' , 
@@ -39,10 +41,8 @@ TOP ['src'] = {
             '__attribute' : {
                 'type' : "argument",
                 'desc' : "target",
-                'argument-type': 'str',
+                'argument-type': projectDict,
                 'returnable' : "returnable",
-                'additionalList' : projectList,
-                'additionalDict' : projectDict,
             },
         }
     },
@@ -80,6 +80,28 @@ TOP ['test'] = {
                 'returnable' : "returnable",
             }
         }
+    },
+    'tt' : {
+        '__attribute' : {
+            'desc' : "next is argument(str)",
+        },
+        'project' : {
+            '__attribute' : {
+                'desc' : "argument test name",
+                'type' : 'argument',
+                'argument-type': 'str',
+            }
+        },
+    },
+    'cc' : {
+        '__attribute' : {
+            'desc' : "next is command (just one)",
+        },
+        'project' : {
+            '__attribute' : {
+                'desc' : "project name",
+            }
+        },
     },
     'vt' : {
         '__attribute' : {

--- a/package/tcmd3.py
+++ b/package/tcmd3.py
@@ -1,4 +1,4 @@
-import CiscoStyleCli
+from CiscoStyleCli import CiscoStyleCli
 import sys
 
 def runReturnFunc(v):

--- a/tcmd.py
+++ b/tcmd.py
@@ -26,7 +26,7 @@ TOP ['src'] = {
                 'argument-type': 'str',
                 'returnable' : "returnable",
             },
-        }
+        },
     },
 }
 TOP ['run'] = {
@@ -44,7 +44,7 @@ TOP ['run'] = {
                 'returnable' : "returnable",
             }
         }
-    }
+    },
 }
 TOP ['test'] = {
     '__attribute' : {


### PR DESCRIPTION
- add new argument-type '...' : this is variable arguments.
- ``` 'endless' : { '__attribute' : { 'desc' : "multiple variant arguments", 'type' : "argument", 'argument-type': '...', 'returnable' : "returnable", }, }, ```

- ``` $  python3 tcmd3.py list argv: ['tcmd3.py', 'list'] functionname: _list
     (commands) src (argument:['tiger_desktop_releaseL', 'bmw_icon_nad_releaseL', 'toyota_24dcm_releaseL', 'tiger_desktop_honda_releaseL', 'tiger_desktop_gen12_release']) project <CR> (argument:{'tiger_desktop_release': 'tiger release on x86', 'bmw_icon_nad_release': 'BMW iconnic sf24', 'toyota_24dcm_release': 'TOYOTA 24cy dcm', 'tiger_desktop_honda_release': 'HONDA 23MY', 'tiger_desktop_gen12_release': 'GM gen12'}) target <CR>
     (commands) run (commands) desktop (commands) committest <CR> (argument:...) endless <CR>
     (commands) quit <CR>
     (commands) list <CR> (commands) detailed <CR>
     (commands) list <CR> (commands) simple <CR>

    $  python3 tcmd3.py run desktop committest aa bb
    argv: ['tcmd3.py', 'run', 'desktop', 'committest', 'aa', 'bb']
    This is common type of prefunc and returnfunc function argument.
    functionname: _common
    function argument: v : {'__cmd__': ['run', 'desktop', 'committest'], 'endless': 'aa', '__return__': 'run desktop committest aa bb'}
    Warning : set your returnfunc. this is templae function of prefunc and returnfunc argument.
    ```